### PR TITLE
Quanticade: update reference speed

### DIFF
--- a/Engines/Quanticade.json
+++ b/Engines/Quanticade.json
@@ -1,6 +1,6 @@
 {
     "private" : false,
-    "nps"     : 800000,
+    "nps"     : 1080000,
     "source"  : "https://github.com/Quanticade/Quanticade",
 
     "build" : {


### PR DESCRIPTION
Due to recent simplification the speed is much higher and needs updating